### PR TITLE
Provide a GitHub PR title from `.git/info/title` file

### DIFF
--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -83,7 +83,11 @@ Creates, checks out and manages GitHub PRs while keeping them reflected in branc
     If ``.git/info/milestone`` file is present, its contents (a single number --- milestone id) are used as milestone.
     If ``.git/info/reviewers`` file is present, its contents (one GitHub login per line) are used to set reviewers.
 
-    The subject of the first unique commit of the branch is used as PR title.
+    The PR title is determined in the following order of priority:
+    1. If the `--title` option is provided, its value is used as the PR title.
+    2. If the `.git/info/title` file is present, its contents (a single line) are used as the PR title.
+    3. If neither the `--title` option is provided nor the `.git/info/title` file is present, the PR title defaults to the subject of the first unique commit on the branch.
+
     If ``.git/info/description`` or ``.github/pull_request_template.md`` template is present, its contents are used as PR description.
     Otherwise (or if ``machete.github.forceDescriptionFromCommitMessage`` is set), PR description is taken from message body of the first unique commit of the branch.
 

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -2756,8 +2756,12 @@ class MacheteClient:
         fork_point = self.fork_point(head, use_overrides=True)
         commits: List[GitLogEntry] = self.__git.get_commits_between(fork_point, head)
 
+        pr_title_file_path = self.__git.get_main_git_subpath('info', 'title')
+        is_pr_title_file = os.path.isfile(pr_title_file_path)
         if opt_title:
             title = opt_title
+        elif is_pr_title_file:
+            title = utils.slurp_file(pr_title_file_path)
         else:
             # git-machete can still see an empty range of unique commits (e.g. in case of yellow edge)
             # even though code hosting may see a non-empty range.

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -638,7 +638,11 @@ long_docs: Dict[str, str] = {
               If `.git/info/milestone` file is present, its contents (a single number — milestone id) are used as milestone.
               If `.git/info/reviewers` file is present, its contents (one GitHub login per line) are used to set reviewers.
 
-              The subject of the first unique commit of the branch is used as PR title.
+              The PR title is determined in the following order of priority:
+              1. If the `--title` option is provided, its value is used as the PR title.
+              2. If the `.git/info/title` file is present, its contents (a single line) are used as the PR title.
+              3. If neither the `--title` option is provided nor the `.git/info/title` file is present, the PR title defaults to the subject of the first unique commit on the branch.
+
               If `.git/info/description` or `.github/pull_request_template.md` template is present, its contents are used as PR description.
               Otherwise (or if `machete.github.forceDescriptionFromCommitMessage` is set), PR description is taken from message body of the first unique commit of the branch.
 

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -954,3 +954,36 @@ class TestGitHubCreatePR(BaseTest):
             Creating a PR from feature to develop... OK, see www.github.com
             """
         )
+
+    def test_github_create_pr_with_title_from_file(self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+        self.patch_symbol(mocker, 'git_machete.github.GitHubToken.for_domain', mock_github_token_for_domain_none)
+        github_api_state = MockGitHubAPIState.with_prs()
+        self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(github_api_state))
+
+        (
+            self.repo_sandbox
+            .new_branch("develop").commit("Some commit").push()
+            .new_branch("feature").commit("Add feature").push()
+        )
+
+        rewrite_branch_layout_file("develop\n\tfeature")
+
+        pr_title = "Feature Implementation"
+        self.repo_sandbox.write_to_file(".git/info/title", pr_title)
+
+        launch_command("github", "create-pr")
+
+        pr = github_api_state.get_pull_by_number(1)
+        assert pr is not None
+        assert pr['title'] == pr_title
+
+        assert_success(
+            ['status'],
+            """
+            develop
+            |
+            o-feature *  PR #1 (some_other_user)
+            """,
+        )
+


### PR DESCRIPTION
Similar to the functionality for adding a PR description from `.git/info/description`, it would be useful to be able to set the PR title from a `.git/info/title` file.

This is a suggestion for an alternative method to the `--title` CLI parameter, which should take precedence over this method.

## Expected behavior

Given that
- `.git/info/title` contains a title, e.g. "Add New Feature"
- `.git/info/description` contains a description, e.g. "# Summary\n..."

When we invoke
```
git machete github create-pr
```

Then a pull request is created with the title and description set.